### PR TITLE
Use custom URL for Eventbrite page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 <p>
   Registration is required and is limited to those affiliated with the
   Biological Sciences Division. Please register
-  at <a href="https://www.eventbrite.com/e/software-carpentry-workshop-uchicago-bsd-2017-tickets-35183005316">software-carpentry-workshop-uchicago-bsd-2017-tickets</a>.
+  at <a href="https://2017-09-23-chicago.eventbrite.com">2017-09-23-chicago.eventbrite.com</a>.
 </p>
 
 <hr/>


### PR DESCRIPTION
This is configured at the bottom of the Manage tab in Eventbrite.